### PR TITLE
add create account feature in CreateAccount router

### DIFF
--- a/recipe-app-cll/src/components/Auth/Auth.js
+++ b/recipe-app-cll/src/components/Auth/Auth.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import fire from "../../util/firebase";
-require("firebase/auth");
+require("firebase/auth"); // to prevent weird bugs by firebase
 
 // log in to the app
 class Auth extends Component {
@@ -20,7 +20,7 @@ class Auth extends Component {
   };
 
   // log in with form data
-  login = (e, account) => {
+  login = e => {
     e.preventDefault();
     fire
       .auth()
@@ -33,9 +33,6 @@ class Auth extends Component {
           loginedEmail: this.state.email
         });
         alert("Successful Login!");
-
-        // set which account to log in as
-        // this.props.setAccount(account);
       })
       .catch(error => {
         // this.props.setMessage(error.message);
@@ -55,7 +52,7 @@ class Auth extends Component {
             onChange={this.handleTermChange}
             type="email"
             name="email"
-            placeholder="Admin Email"
+            placeholder="Email"
           />
           <br />
           <input
@@ -66,11 +63,8 @@ class Auth extends Component {
             placeholder="Password"
           />
           <br />
-          <button type="submit" onClick={e => this.login(e, "student")}>
+          <button type="submit" onClick={e => this.login(e)}>
             Log in
-          </button>
-          <button type="submit" onClick={e => this.login(e, "admin")}>
-            Log in as Admin
           </button>
         </form>
       </div>

--- a/recipe-app-cll/src/components/CreateAccount/index.js
+++ b/recipe-app-cll/src/components/CreateAccount/index.js
@@ -1,13 +1,68 @@
 import React from "react";
+import fire from "../../util/firebase";
+require("firebase/auth"); // to prevent weird bugs by firebase
 
 export default class CreateAccount extends React.Component {
-    render() {
-        return (
-            <div>
-                <h1>I am the Create Account Component</h1>
-                <h2>Edit me from src/components/CreateAccount/index.js</h2>
-                <h2>Edit my styles from src/components/App/App.css</h2>
-            </div>
-        )
-    }
+  state = {
+    email: "",
+    password: ""
+  };
+
+  // update state with contents of input field
+  handleTermChange = e => {
+    this.setState({
+      [e.target.name]: e.target.value
+    });
+    if (this.props.message) this.props.setMessage(""); // reset error message if there was one
+  };
+
+  // create account
+  createAccount = (e, email, password) => {
+    e.preventDefault();
+    fire
+      .auth()
+      .createUserWithEmailAndPassword(this.state.email, this.state.password)
+      .then(() => {
+        alert("Account Created!");
+      })
+      .catch(error => {
+        console.log(error);
+        alert(error);
+      });
+  };
+
+  render() {
+    return (
+      <div>
+        <h1>I am the Create Account Component</h1>
+        <h2>Edit me from src/components/CreateAccount/index.js</h2>
+        <h2>Edit my styles from src/components/App/App.css</h2>
+        {/* content separator */}
+        <br />
+        <label>Create An Account :)</label>
+        <form autoComplete="off">
+          <input
+            value={this.state.email}
+            onChange={this.handleTermChange}
+            type="email"
+            name="email"
+            placeholder="Email"
+          />
+          <br />
+          <input
+            value={this.state.password}
+            onChange={this.handleTermChange}
+            type="password"
+            name="password"
+            placeholder="Password"
+          />
+          <br />
+          <button type="submit" onClick={this.createAccount}>
+            Create
+          </button>
+        </form>
+        <br />
+      </div>
+    );
+  }
 }


### PR DESCRIPTION
You should now be able to create account in the path: http://localhost:3000/create-account

Go to the firebase-console/Auth to see all existing accounts as well.

<img width="688" alt="firebase-createacc" src="https://user-images.githubusercontent.com/34314658/51551155-d184ef80-1ea8-11e9-9040-8880e8b1d952.png">

Issue:
Possible to change Router's component's `index.js` into the Class Name as usual? It will be a mess if all are index.js.

TODO:
1. change recipe list into table items & extend fields.
2. organise components into individual router.
3. retain login status via cookies etc.